### PR TITLE
Хуки для реализации создания больших миниатюр

### DIFF
--- a/files/inc/files.upload.php
+++ b/files/inc/files.upload.php
@@ -585,6 +585,12 @@ class UploadController{
                         '&_method=DELETE&x='.cot::$sys['xk'];
                     $file->deleteType = 'POST';
 
+                    /* === Hook === */
+                     foreach (cot_getextplugins('files.upload.objfile.save') as $pl)
+                     {
+                          include $pl;
+                     }
+                    /* ===== */                    
 
                     $editForm = array(
                         0 => array(

--- a/files/inc/files.upload.php
+++ b/files/inc/files.upload.php
@@ -138,6 +138,14 @@ class UploadController{
                 $file['thumbnail'] = cot::$cfg['mainurl'] . '/' . cot_files_thumb($row->file_id);
             }else{
                 $file['thumbnailUrl'] = cot::$cfg['mainurl'] . '/' . $row->icon;
+                
+                    /* === Hook === */
+                    foreach (cot_getextplugins('files.upload.row.img') as $pl)
+                    {
+                         include $pl;
+                    }
+                    /* ===== */                
+                
             }
 
             if (!$multi){


### PR DESCRIPTION
Для создания большой миниатюры, которая может вставляться в визуальный редактор, нужно создавать ее до публикации. Чтобы не создавать в этом месте конкретной записи, предлагаю добавить хук, а запись уже можно будет добавлять из своего плагина.
Это поможет создать свой тег, например {%=file.thumbnailBig%}  для files.templates.tpl, благодаря чему можно дальше внедрять вставку большой миниатюры с водяным знаком в CKEditor c последующей обработкой в parser.last.